### PR TITLE
version bump and change schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
   name="django-json-rpc",
-  version="0.6.2.lyst3",
+  version="0.6.2lyst4",
   description="A simple JSON-RPC implementation for Django",
   long_description="""
 Features:


### PR DESCRIPTION
@tsifrer @boffbowsh @public @iserko 

not sure why earlier we used `0.6.2.lyst2`

started when @tsifrer was getting 

```
ERROR:devpi_builder.cli:Failed to create wheel for django-json-rpc 0.6.2.lyst3:
The version specified ('0.6.2.lyst3') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```